### PR TITLE
fix(macos): Implement FTP NLST fallback to LIST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MacOS
+.DS_Store
+
 # Project-specific
 build/dist/
 *.exe


### PR DESCRIPTION
This PR solves a compatibility issue with the PS5 FTP server, which can return a 502 error when attempting to list directories using NLST.

Changes:
- Modified DumpScanner to catch error_perm exceptions.
- Added logic to check for specific 502 error codes.
- Implemented _list_names_fallback method which uses the LIST command as an alternative when NLST fails.
- Updated .gitignore to exclude .DS_Store files.

--- 

**If there is an optimal option that allows the NLST command to work without having to implement LIST, it would be a better solution.**
**I don’t usually work with Python, so there is probably a cleaner solution.**